### PR TITLE
Replace dot with comma

### DIFF
--- a/AWSIoTPythonSDK/MQTTLib.py
+++ b/AWSIoTPythonSDK/MQTTLib.py
@@ -585,7 +585,7 @@ class AWSIoTMQTTShadowClient:
 
         """
         # AWSIoTMQTTClient.configureIAMCredentials
-        self._AWSIoTMQTTClient.configureIAMCredentials(AWSAccessKeyID, AWSSecretAccessKey. AWSSTSToken)
+        self._AWSIoTMQTTClient.configureIAMCredentials(AWSAccessKeyID, AWSSecretAccessKey, AWSSTSToken)
 
     def configureCredentials(self, CAFilePath, KeyPath="", CertificatePath=""):  # Should be good for MutualAuth and Websocket
         """


### PR DESCRIPTION
There was a typo in MQTTLib.py, where there was a `.` in a function call instead of a `,`. This made the `configureIAMCredentials` method fail.