### PR TITLE
Fix docstring comments for configureCredentials and configureAutoReconnectBackoffTime methods of AWSIoTMQTTShadowClient class.

### DIFF
--- a/AWSIoTPythonSDK/MQTTLib.py
+++ b/AWSIoTPythonSDK/MQTTLib.py
@@ -707,21 +707,25 @@ class AWSIoTMQTTShadowClient:
         """
         **Description**
 
-        Used to configure the rootCA, private key and certificate files. Should be called before connect.
+        Used to configure the auto-reconnect backoff timing. Should be called before connect.
 
         **Syntax**
 
         .. code:: python
 
-          myAWSIoTMQTTShadowClient.configureCredentials("PATH/TO/ROOT_CA", "PATH/TO/PRIVATE_KEY", "PATH/TO/CERTIFICATE")
+          # Configure the auto-reconnect backoff to start with 1 second and use 128 seconds as a maximum back off time.
+          # Connection over 20 seconds is considered stable and will reset the back off time back to its base.
+          myAWSIoTMQTTShadowClient.configureAutoReconnectBackoffTime(1, 128, 20)
 
         **Parameters**
 
-        *CAFilePath* - Path to read the root CA file. Required for all connection types.
+        *baseReconnectQuietTimeSecond* - The initial back off time to start with, in seconds. 
+        Should be less than the stableConnectionTime.
 
-        *KeyPath* - Path to read the private key. Required for X.509 certificate based connection.
+        *maxReconnectQuietTimeSecond* - The maximum back off time, in seconds.
 
-        *CertificatePath* - Path to read the certificate. Required for X.509 certificate based connection.
+        *stableConnectionTimeSecond* - The number of seconds for a connection to last to be considered as stable. 
+        Back off time will be reset to base once the connection is stable.
 
         **Returns**
 

--- a/AWSIoTPythonSDK/MQTTLib.py
+++ b/AWSIoTPythonSDK/MQTTLib.py
@@ -693,11 +693,25 @@ class AWSIoTMQTTShadowClient:
         """
         **Description**
 
+        Used to configure the rootCA, private key and certificate files. Should be called before connect.
+
         **Syntax**
+
+        .. code:: python
+
+          myAWSIoTMQTTShadowClient.configureCredentials("PATH/TO/ROOT_CA", "PATH/TO/PRIVATE_KEY", "PATH/TO/CERTIFICATE")
 
         **Parameters**
 
+        *CAFilePath* - Path to read the root CA file. Required for all connection types.
+
+        *KeyPath* - Path to read the private key. Required for X.509 certificate based connection.
+
+        *CertificatePath* - Path to read the certificate. Required for X.509 certificate based connection.
+
         **Returns**
+
+        None
 
         """
         # AWSIoTMQTTClient.configureCredentials


### PR DESCRIPTION
Fix docstring comments for configureCredentials and configureAutoReconnectBackoffTime methods of AWSIoTMQTTShadowClient class.