### PR TITLE
shadowManager: fix deadlock in basicShadowSubscribe

### DIFF
--- a/AWSIoTPythonSDK/core/shadow/shadowManager.py
+++ b/AWSIoTPythonSDK/core/shadow/shadowManager.py
@@ -66,12 +66,16 @@ class shadowManager:
 
     def basicShadowSubscribe(self, srcShadowName, srcShadowAction, srcCallback):
         self._shadowSubUnsubOperationLock.acquire()
-        currentShadowAction = _shadowAction(srcShadowName, srcShadowAction)
-        if currentShadowAction.isDelta:
-            self._mqttCoreHandler.subscribe(currentShadowAction.getTopicDelta(), 0, srcCallback)
-        else:
-            self._mqttCoreHandler.subscribe(currentShadowAction.getTopicAccept(), 0, srcCallback)
-            self._mqttCoreHandler.subscribe(currentShadowAction.getTopicReject(), 0, srcCallback)
+        try:
+                currentShadowAction = _shadowAction(srcShadowName, srcShadowAction)
+                if currentShadowAction.isDelta:
+                    self._mqttCoreHandler.subscribe(currentShadowAction.getTopicDelta(), 0, srcCallback)
+                else:
+                    self._mqttCoreHandler.subscribe(currentShadowAction.getTopicAccept(), 0, srcCallback)
+                    self._mqttCoreHandler.subscribe(currentShadowAction.getTopicReject(), 0, srcCallback)
+        except:
+            self._shadowSubUnsubOperationLock.release()
+            raise
         time.sleep(2)
         self._shadowSubUnsubOperationLock.release()
 


### PR DESCRIPTION
If the MQTT connection is temporarily lost, subscribe will throw an
exception and leave _shadowSubUnsubOperationLock locked.  The next
attempt to lock this lock will deadlock, preventing any future use
of the shadow.

Release the lock when an exception occurs so that the shadow can
continue to be used after the MQTT connection auto-reconnects.