### PR TITLE
Move paho client.py module-level imports to top of file

### DIFF
--- a/AWSIoTPythonSDK/core/protocol/paho/client.py
+++ b/AWSIoTPythonSDK/core/protocol/paho/client.py
@@ -21,6 +21,10 @@ import platform
 import random
 import select
 import socket
+import struct
+import sys
+import threading
+import time
 HAVE_SSL = True
 try:
     import ssl
@@ -30,10 +34,7 @@ except:
     HAVE_SSL = False
     cert_reqs = None
     tls_version = None
-import struct
-import sys
-import threading
-import time
+
 HAVE_DNS = True
 try:
     import dns.resolver


### PR DESCRIPTION
This change is necessary to access module-level imports (e.g., the
time import), and also fixes some lint. Before this change, running
in Python 2.7.12, one could encounter:

```
<type 'exceptions.AttributeError'>: 'NoneType' object has no attribute 'time'
```