### PR TITLE
Can't reconnect if use websocket with Amazon Cognito Identity

### DIFF
--- a/AWSIoTPythonSDK/MQTTLib.py
+++ b/AWSIoTPythonSDK/MQTTLib.py
@@ -201,6 +201,36 @@ class AWSIoTMQTTClient:
         iam_credentials_provider.set_access_key_id(AWSAccessKeyID)
         iam_credentials_provider.set_secret_access_key(AWSSecretAccessKey)
         iam_credentials_provider.set_session_token(AWSSessionToken)
+        self.configureIAMCredentialsProvider(iam_credentials_provider)
+
+    def configureIAMCredentialsProvider(self, iam_credentials_provider):
+        """
+        **Description**
+
+        Used to configure/update the custom IAM credentials provider for Websocket SigV4 connection to
+        AWS IoT. Should be called before connect.
+
+        **Syntax**
+
+        .. code:: python
+
+          myAWSIoTMQTTClient.configureIAMCredentialsProvider(extendedIAMCredentialsProvider)
+
+        .. note::
+
+          Hard-coding credentials into custom script is NOT recommended. Please use AWS Cognito identity service
+          or other credential provider.
+
+        **Parameters**
+
+        *iam_credentials_provider* - IAMCredentialsProvider which can provide AWS Access Key, AWS Secret Access Key and
+                                     AWS Session Token from IAM credentials.
+
+        **Returns**
+
+        None
+
+        """
         self._mqtt_core.configure_iam_credentials(iam_credentials_provider)
 
     def configureCredentials(self, CAFilePath, KeyPath="", CertificatePath=""):  # Should be good for MutualAuth certs config and Websocket rootCA config

--- a/AWSIoTPythonSDK/core/protocol/internal/clients.py
+++ b/AWSIoTPythonSDK/core/protocol/internal/clients.py
@@ -84,9 +84,7 @@ class InternalAsyncMqttClient(object):
                                       cert_reqs=ssl.CERT_REQUIRED, tls_version=ssl.PROTOCOL_SSLv23)
 
     def set_iam_credentials_provider(self, iam_credentials_provider):
-        self._paho_client.configIAMCredentials(iam_credentials_provider.get_access_key_id(),
-                                               iam_credentials_provider.get_secret_access_key(),
-                                               iam_credentials_provider.get_session_token())
+        self._paho_client.configIAMCredentialsProvider(iam_credentials_provider)
 
     def set_endpoint_provider(self, endpoint_provider):
         self._endpoint_provider = endpoint_provider


### PR DESCRIPTION
### Problem description
Can't reconnect to AWS IoT with websocket and IAM credentials which was retrieved from AWS Cognito Identity if execute `samples/basicPubSub/basicPubSub_CognitoSTS.py` for a long time more than 1 hour.

### Caused by...
The session token from AWS Cognito Identity will expire after 1 hour.
But current logic will reconnect with credentials which is specified at initialization.

https://github.com/aws/aws-iot-device-sdk-python/blob/v1.3.1/AWSIoTPythonSDK/core/protocol/paho/client.py#L787
```
self._ssl = SecuredWebSocketCore(rawSSL, self._host, self._port, self._AWSAccessKeyIDCustomConfig, self._AWSSecretAccessKeyCustomConfig, self._AWSSessionTokenCustomConfig) # Overeride the _ssl socket
```

### Reproduce
1. checkout `v1.3.1` tag
2. extend timeout to keep script execution until `wssHandShakeError` has been occurred
```
myAWSIoTMQTTClient.configureConnectDisconnectTimeout(1000)
myAWSIoTMQTTClient.configureMQTTOperationTimeout(1000)
```
3. execute sample script
4. wait until session token has been expired (more than 1 hour)
5. kill tcp session (I tried to down eth0 temporarily)
```
sudo ifdown eth0 && sleep 90 && sudo ifup eth0
```

### Measures to fix
Specify credentials provider instead of fixed credentials when configure.
