### PR TITLE
Added validation to basicDiscovery MTLS args

### DIFF
--- a/samples/greengrass/basicDiscovery.py
+++ b/samples/greengrass/basicDiscovery.py
@@ -65,6 +65,18 @@ if not args.certificatePath or not args.privateKeyPath:
     parser.error("Missing credentials for authentication.")
     exit(2)
 
+if not os.path.isfile(rootCAPath):
+    parser.error("Root CA path does not exist {}".format(rootCAPath))
+    exit(3)
+
+if not os.path.isfile(certificatePath):
+    parser.error("No certificate found at {}".format(certificatePath))
+    exit(3)
+
+if not os.path.isfile(privateKeyPath):
+    parser.error("No private key found at {}".format(privateKeyPath))
+    exit(3)
+
 # Configure logging
 logger = logging.getLogger("AWSIoTPythonSDK.core")
 logger.setLevel(logging.DEBUG)


### PR DESCRIPTION
*Issue #, if available:*  SDK-7268

*Description of changes:* The sample will now error if the root CA or cert/key are not valid paths/do not exist.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
