### PR TITLE
Add stepTimeoutInMinutes paramenters

### DIFF
--- a/AWSIoTPythonSDK/MQTTLib.py
+++ b/AWSIoTPythonSDK/MQTTLib.py
@@ -1613,7 +1613,7 @@ class AWSIoTMQTTThingJobsClient(_AWSIoTMQTTDelegatingClient):
         payload = self._thingJobManager.serializeClientTokenPayload()
         return self._AWSIoTMQTTClient.publish(topic, payload, self._QoS)
 
-    def sendJobsStartNext(self, statusDetails=None):
+    def sendJobsStartNext(self, statusDetails=None, stepTimeoutInMinutes=None):
         """
         **Description**
 
@@ -1631,16 +1631,18 @@ class AWSIoTMQTTThingJobsClient(_AWSIoTMQTTDelegatingClient):
 
         *statusDetails* - Dictionary containing the key value pairs to use for the status details of the job execution
 
+        *stepTimeoutInMinutes - Specifies the amount of time this device has to finish execution of this job. 
+
         **Returns**
 
         True if the publish request has been sent to paho. False if the request did not reach paho.
 
         """
         topic = self._thingJobManager.getJobTopic(jobExecutionTopicType.JOB_START_NEXT_TOPIC, jobExecutionTopicReplyType.JOB_REQUEST_TYPE)
-        payload = self._thingJobManager.serializeStartNextPendingJobExecutionPayload(statusDetails)
+        payload = self._thingJobManager.serializeStartNextPendingJobExecutionPayload(statusDetails, stepTimeoutInMinutes)
         return self._AWSIoTMQTTClient.publish(topic, payload, self._QoS)
 
-    def sendJobsUpdate(self, jobId, status, statusDetails=None, expectedVersion=0, executionNumber=0, includeJobExecutionState=False, includeJobDocument=False):
+    def sendJobsUpdate(self, jobId, status, statusDetails=None, expectedVersion=0, executionNumber=0, includeJobExecutionState=False, includeJobDocument=False, stepTimeoutInMinutes=None):
         """
         **Description**
 
@@ -1678,13 +1680,15 @@ class AWSIoTMQTTThingJobsClient(_AWSIoTMQTTDelegatingClient):
 
         *includeJobDocument* - When included and set to True, the response contains the JobDocument. The default is False.
 
+        *stepTimeoutInMinutes - Specifies the amount of time this device has to finish execution of this job. 
+
         **Returns**
 
         True if the publish request has been sent to paho. False if the request did not reach paho.
 
         """
         topic = self._thingJobManager.getJobTopic(jobExecutionTopicType.JOB_UPDATE_TOPIC, jobExecutionTopicReplyType.JOB_REQUEST_TYPE, jobId)
-        payload = self._thingJobManager.serializeJobExecutionUpdatePayload(status, statusDetails, expectedVersion, executionNumber, includeJobExecutionState, includeJobDocument)
+        payload = self._thingJobManager.serializeJobExecutionUpdatePayload(status, statusDetails, expectedVersion, executionNumber, includeJobExecutionState, includeJobDocument, stepTimeoutInMinutes)
         return self._AWSIoTMQTTClient.publish(topic, payload, self._QoS)
 
     def sendJobsDescribe(self, jobId, executionNumber=0, includeJobDocument=True):

--- a/AWSIoTPythonSDK/core/jobs/thingJobManager.py
+++ b/AWSIoTPythonSDK/core/jobs/thingJobManager.py
@@ -37,6 +37,7 @@ _EXEXCUTION_NUMBER_KEY = 'executionNumber'
 _INCLUDE_JOB_EXECUTION_STATE_KEY = 'includeJobExecutionState'
 _INCLUDE_JOB_DOCUMENT_KEY = 'includeJobDocument'
 _CLIENT_TOKEN_KEY = 'clientToken'
+_STEP_TIMEOUT_IN_MINUTES_KEY = 'stepTimeoutInMinutes'
 
 #The type of job topic.
 class jobExecutionTopicType(object):
@@ -112,7 +113,7 @@ class thingJobManager:
         else:
             return '{0}{1}/jobs/{2}{3}'.format(_BASE_THINGS_TOPIC, self._thingName, srcJobExecTopicType[_JOB_OPERATION_INDEX], srcJobExecTopicReplyType[_JOB_SUFFIX_INDEX])
 
-    def serializeJobExecutionUpdatePayload(self, status, statusDetails=None, expectedVersion=0, executionNumber=0, includeJobExecutionState=False, includeJobDocument=False):
+    def serializeJobExecutionUpdatePayload(self, status, statusDetails=None, expectedVersion=0, executionNumber=0, includeJobExecutionState=False, includeJobDocument=False, stepTimeoutInMinutes=None):
         executionStatus = _getExecutionStatus(status)
         if executionStatus is None:
             return None
@@ -129,6 +130,8 @@ class thingJobManager:
             payload[_INCLUDE_JOB_DOCUMENT_KEY] = True
         if self._clientToken is not None:
             payload[_CLIENT_TOKEN_KEY] = self._clientToken
+        if stepTimeoutInMinutes is not None:
+            payload[_STEP_TIMEOUT_IN_MINUTES_KEY] = stepTimeoutInMinutes
         return json.dumps(payload)
 
     def serializeDescribeJobExecutionPayload(self, executionNumber=0, includeJobDocument=True):
@@ -139,12 +142,14 @@ class thingJobManager:
             payload[_CLIENT_TOKEN_KEY] = self._clientToken
         return json.dumps(payload)
 
-    def serializeStartNextPendingJobExecutionPayload(self, statusDetails=None):
+    def serializeStartNextPendingJobExecutionPayload(self, statusDetails=None, stepTimeoutInMinutes=None):
         payload = {}
         if self._clientToken is not None:
             payload[_CLIENT_TOKEN_KEY] = self._clientToken
         if statusDetails is not None:
             payload[_STATUS_DETAILS_KEY] = statusDetails
+        if stepTimeoutInMinutes is not None:
+            payload[_STEP_TIMEOUT_IN_MINUTES_KEY] = stepTimeoutInMinutes
         return json.dumps(payload)
 
     def serializeClientTokenPayload(self):


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*

Add support for the optional stepTimeoutInMinutes to sendJobsStartNext and sendJobsUpdate. This matches the document for StartNextPendingJobExecution and UpdateJobExecution on https://docs.aws.amazon.com/iot/latest/developerguide/jobs-api.html.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
