### PR TITLE
Support for ack callbacks on offline sub/unsub requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.pyenv/
+.vscode/
+build/
+*.pyc

--- a/AWSIoTPythonSDK/core/protocol/internal/workers.py
+++ b/AWSIoTPythonSDK/core/protocol/internal/workers.py
@@ -242,15 +242,15 @@ class EventConsumer(object):
         self._logger.debug("Processed offline publish request")
 
     def _handle_offline_subscribe(self, request):
-        topic, qos, message_callback = request.data
+        topic, qos, message_callback, ack_callback = request.data
         self._subscription_manager.add_record(topic, qos, message_callback)
-        self._internal_async_client.subscribe(topic, qos)
+        self._internal_async_client.subscribe(topic, qos, ack_callback)
         self._logger.debug("Processed offline subscribe request")
 
     def _handle_offline_unsubscribe(self, request):
-        topic = request.data
+        topic, ack_callback = request.data
         self._subscription_manager.remove_record(topic)
-        self._internal_async_client.unsubscribe(topic)
+        self._internal_async_client.unsubscribe(topic, ack_callback)
         self._logger.debug("Processed offline unsubscribe request")
 
 

--- a/AWSIoTPythonSDK/core/protocol/mqtt_core.py
+++ b/AWSIoTPythonSDK/core/protocol/mqtt_core.py
@@ -310,7 +310,7 @@ class MqttCore(object):
     def subscribe_async(self, topic, qos, ack_callback=None, message_callback=None):
         self._logger.info("Performing async subscribe...")
         if ClientStatus.STABLE != self._client_status.get_status():
-            self._handle_offline_request(RequestTypes.SUBSCRIBE, (topic, qos, message_callback))
+            self._handle_offline_request(RequestTypes.SUBSCRIBE, (topic, qos, message_callback, ack_callback))
             return FixedEventMids.QUEUED_MID
         else:
             rc, mid = self._subscribe_async(topic, qos, ack_callback, message_callback)
@@ -328,7 +328,7 @@ class MqttCore(object):
         self._logger.info("Performing sync unsubscribe...")
         ret = False
         if ClientStatus.STABLE != self._client_status.get_status():
-            self._handle_offline_request(RequestTypes.UNSUBSCRIBE, topic)
+            self._handle_offline_request(RequestTypes.UNSUBSCRIBE, (topic))
         else:
             event = Event()
             rc, mid = self._unsubscribe_async(topic, self._create_blocking_ack_callback(event))
@@ -342,7 +342,7 @@ class MqttCore(object):
     def unsubscribe_async(self, topic, ack_callback=None):
         self._logger.info("Performing async unsubscribe...")
         if ClientStatus.STABLE != self._client_status.get_status():
-            self._handle_offline_request(RequestTypes.UNSUBSCRIBE, topic)
+            self._handle_offline_request(RequestTypes.UNSUBSCRIBE, (topic, ack_callback))
             return FixedEventMids.QUEUED_MID
         else:
             rc, mid = self._unsubscribe_async(topic, ack_callback)


### PR DESCRIPTION
*Issue #, if available:* https://github.com/aws/aws-iot-device-sdk-python/issues/218

*Description of changes:* Added support for ack_callbacks to be called when subscribing/unsubscribing via offline requests

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
