### PR TITLE
MqttCore.connect: return false instead of raising

### DIFF
--- a/AWSIoTPythonSDK/MQTTLib.py
+++ b/AWSIoTPythonSDK/MQTTLib.py
@@ -44,12 +44,12 @@ class AWSIoTMQTTClient:
         - TLSv1.2 Mutual Authentication
 
         X.509 certificate-based secured MQTT connection to AWS IoT
-        
+
         - Websocket SigV4
 
         IAM credential-based secured MQTT connection over Websocket to AWS IoT
 
-        It provides basic synchronous MQTT operations in the classic MQTT publish-subscribe 
+        It provides basic synchronous MQTT operations in the classic MQTT publish-subscribe
         model, along with configurations of on-top features:
 
         - Auto reconnect/resubscribe
@@ -72,7 +72,7 @@ class AWSIoTMQTTClient:
         **Parameters**
 
         *clientID* - String that denotes the client identifier used to connect to AWS IoT.
-        If empty string were provided, client id for this connection will be randomly generated 
+        If empty string were provided, client id for this connection will be randomly generated
         n server side.
 
         *protocolType* - MQTT version in use for this connection. Could be :code:`AWSIoTPythonSDK.MQTTLib.MQTTv3_1` or :code:`AWSIoTPythonSDK.MQTTLib.MQTTv3_1_1`
@@ -133,7 +133,7 @@ class AWSIoTMQTTClient:
         **Returns**
 
         None
-        
+
         """
         self._mqtt_core.clear_last_will()
 
@@ -174,7 +174,7 @@ class AWSIoTMQTTClient:
         """
         **Description**
 
-        Used to configure/update the custom IAM credentials for Websocket SigV4 connection to 
+        Used to configure/update the custom IAM credentials for Websocket SigV4 connection to
         AWS IoT. Should be called before connect.
 
         **Syntax**
@@ -254,12 +254,12 @@ class AWSIoTMQTTClient:
 
         **Parameters**
 
-        *baseReconnectQuietTimeSecond* - The initial back off time to start with, in seconds. 
+        *baseReconnectQuietTimeSecond* - The initial back off time to start with, in seconds.
         Should be less than the stableConnectionTime.
 
         *maxReconnectQuietTimeSecond* - The maximum back off time, in seconds.
 
-        *stableConnectionTimeSecond* - The number of seconds for a connection to last to be considered as stable. 
+        *stableConnectionTimeSecond* - The number of seconds for a connection to last to be considered as stable.
         Back off time will be reset to base once the connection is stable.
 
         **Returns**
@@ -318,7 +318,7 @@ class AWSIoTMQTTClient:
 
         .. note::
 
-          Make sure the draining speed is fast enough and faster than the publish rate. Slow draining 
+          Make sure the draining speed is fast enough and faster than the publish rate. Slow draining
           could result in inifinite draining process.
 
         **Parameters**
@@ -336,7 +336,7 @@ class AWSIoTMQTTClient:
         """
         **Description**
 
-        Used to configure the time in seconds to wait for a CONNACK or a disconnect to complete. 
+        Used to configure the time in seconds to wait for a CONNACK or a disconnect to complete.
         Should be called before connect.
 
         **Syntax**
@@ -361,7 +361,7 @@ class AWSIoTMQTTClient:
         """
         **Description**
 
-        Used to configure the timeout in seconds for MQTT QoS 1 publish, subscribe and unsubscribe. 
+        Used to configure the timeout in seconds for MQTT QoS 1 publish, subscribe and unsubscribe.
         Should be called before connect.
 
         **Syntax**
@@ -434,7 +434,7 @@ class AWSIoTMQTTClient:
 
         """
         self._mqtt_core.configure_socket_factory(socket_factory)
-        
+
     def enableMetricsCollection(self):
         """
         **Description**
@@ -483,7 +483,7 @@ class AWSIoTMQTTClient:
         self._mqtt_core.disable_metrics_collection()
 
     # MQTT functionality APIs
-    def connect(self, keepAliveIntervalSecond=600):
+    def connect(self, keepAliveIntervalSecond=600, raise_on_timeout=True):
         """
         **Description**
 
@@ -510,7 +510,7 @@ class AWSIoTMQTTClient:
 
         """
         self._load_callbacks()
-        return self._mqtt_core.connect(keepAliveIntervalSecond)
+        return self._mqtt_core.connect(keepAliveIntervalSecond, raise_on_timeout=raise_on_timeout)
 
     def connectAsync(self, keepAliveIntervalSecond=600, ackCallback=None):
         """
@@ -877,7 +877,7 @@ class _AWSIoTMQTTDelegatingClient(object):
         **Parameters**
 
         *clientID* - String that denotes the client identifier used to connect to AWS IoT.
-        If empty string were provided, client id for this connection will be randomly generated 
+        If empty string were provided, client id for this connection will be randomly generated
         n server side.
 
         *protocolType* - MQTT version in use for this connection. Could be :code:`AWSIoTPythonSDK.MQTTLib.MQTTv3_1` or :code:`AWSIoTPythonSDK.MQTTLib.MQTTv3_1_1`
@@ -944,7 +944,7 @@ class _AWSIoTMQTTDelegatingClient(object):
         **Returns**
 
         None
-        
+
         """
         # AWSIoTMQTTClient.clearLastWill()
         self._AWSIoTMQTTClient.clearLastWill()
@@ -983,7 +983,7 @@ class _AWSIoTMQTTDelegatingClient(object):
         """
         **Description**
 
-        Used to configure/update the custom IAM credentials for the underneath AWS IoT MQTT Client 
+        Used to configure/update the custom IAM credentials for the underneath AWS IoT MQTT Client
         for Websocket SigV4 connection to AWS IoT. Should be called before connect. This is a public
         facing API inherited by application level public clients.
 
@@ -1083,7 +1083,7 @@ class _AWSIoTMQTTDelegatingClient(object):
         """
         **Description**
 
-        Used to configure the time in seconds to wait for a CONNACK or a disconnect to complete. 
+        Used to configure the time in seconds to wait for a CONNACK or a disconnect to complete.
         Should be called before connect. This is a public facing API inherited by application level public clients.
 
         **Syntax**
@@ -1110,7 +1110,7 @@ class _AWSIoTMQTTDelegatingClient(object):
         """
         **Description**
 
-        Used to configure the timeout in seconds for MQTT QoS 1 publish, subscribe and unsubscribe. 
+        Used to configure the timeout in seconds for MQTT QoS 1 publish, subscribe and unsubscribe.
         Should be called before connect. This is a public facing API inherited by application level public clients.
 
         **Syntax**
@@ -1187,7 +1187,7 @@ class _AWSIoTMQTTDelegatingClient(object):
 
         """
         self._AWSIoTMQTTClient.configureSocketFactory(socket_factory)
-        
+
     def enableMetricsCollection(self):
         """
         **Description**
@@ -1259,7 +1259,7 @@ class _AWSIoTMQTTDelegatingClient(object):
 
         **Parameters**
 
-        *keepAliveIntervalSecond* - Time in seconds for interval of sending MQTT ping request. 
+        *keepAliveIntervalSecond* - Time in seconds for interval of sending MQTT ping request.
         Default set to 30 seconds.
 
         **Returns**
@@ -1685,7 +1685,7 @@ class AWSIoTMQTTThingJobsClient(_AWSIoTMQTTDelegatingClient):
 
         *statusDetails* - Dictionary containing the key value pairs to use for the status details of the job execution
 
-        *stepTimeoutInMinutes - Specifies the amount of time this device has to finish execution of this job. 
+        *stepTimeoutInMinutes - Specifies the amount of time this device has to finish execution of this job.
 
         **Returns**
 
@@ -1734,7 +1734,7 @@ class AWSIoTMQTTThingJobsClient(_AWSIoTMQTTDelegatingClient):
 
         *includeJobDocument* - When included and set to True, the response contains the JobDocument. The default is False.
 
-        *stepTimeoutInMinutes - Specifies the amount of time this device has to finish execution of this job. 
+        *stepTimeoutInMinutes - Specifies the amount of time this device has to finish execution of this job.
 
         **Returns**
 


### PR DESCRIPTION
*Issue #, if available:* [248](https://github.com/aws/aws-iot-device-sdk-python/issues/248)

*Description of changes:* When `MqttCore.connect_async` successfully returns when it is called from `MqttCore.connect`, `self._event_consumer.stop()` is never called so neither is `self._internal_async_client.stop_background_network_io()`. This means that when `MqttCore.connect_async` returns and `not event.wait(self._connect_disconnect_timeout_sec) == True` the call to `MqttCore.connect` will raise an error, but the system might still connect to the broker as the background_network_io is still running. A side effect of this is, if the user tries to call the connect method when it "fails" like this:
```
connected = False
while not connected:
  try:
    client.connect()
  except connectTimeoutException:
    pass
  else:
    connected = True
``` 
The daemon threads spawned by `self._start_workers()` will be spawned again and thus duplicated.

With these changes, the user will be able to do something like:
```
if client.connect():
  print('Client connected!')
else:
  print('Client did not connect, but will retry automatically')
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
