### PR TITLE
makes support for named shadow

### DIFF
--- a/AWSIoTPythonSDK/core/shadow/deviceShadow.py
+++ b/AWSIoTPythonSDK/core/shadow/deviceShadow.py
@@ -58,12 +58,12 @@ class deviceShadow:
 
         The class that denotes a local/client-side device shadow instance.
 
-        Users can perform shadow operations on this instance to retrieve and modify the 
-        corresponding shadow JSON document in AWS IoT Cloud. The following shadow operations 
+        Users can perform shadow operations on this instance to retrieve and modify the
+        corresponding shadow JSON document in AWS IoT Cloud. The following shadow operations
         are available:
 
         - Get
-        
+
         - Update
 
         - Delete
@@ -72,7 +72,7 @@ class deviceShadow:
 
         - Cancel listening on delta
 
-        This is returned from :code:`AWSIoTPythonSDK.MQTTLib.AWSIoTMQTTShadowClient.createShadowWithName` function call. 
+        This is returned from :code:`AWSIoTPythonSDK.MQTTLib.AWSIoTMQTTShadowClient.createShadowWithName` function call.
         No need to call directly from user scripts.
 
         """
@@ -160,21 +160,21 @@ class deviceShadow:
                             processCustomCallback.start()
 
     def _parseTopicAction(self, srcTopic):
-        ret = None
         fragments = srcTopic.split('/')
-        if fragments[5] == "delta":
-            ret = "delta"
-        else:
-            ret = fragments[4]
-        return ret
+        offset = 2 if "/name/" in srcTopic else 0
+        if fragments[5 + offset] == "delta":
+            return "delta"
+        return fragments[4 + offset]
 
     def _parseTopicType(self, srcTopic):
         fragments = srcTopic.split('/')
-        return fragments[5]
+        return fragments[7 if "/name/" in srcTopic else 5]
 
     def _parseTopicShadowName(self, srcTopic):
         fragments = srcTopic.split('/')
-        return fragments[2]
+        if "/name/" in srcTopic:
+            return fragments[2] + ':' + fragments[5] # named shadow: "thingName:shadowName"
+        return fragments[2] # classic shadow: "shadowName" (same as thingName)
 
     def _timerHandler(self, srcActionName, srcToken):
         with self._dataStructureLock:
@@ -198,10 +198,10 @@ class deviceShadow:
         """
         **Description**
 
-        Retrieve the device shadow JSON document from AWS IoT by publishing an empty JSON document to the 
-        corresponding shadow topics. Shadow response topics will be subscribed to receive responses from 
-        AWS IoT regarding the result of the get operation. Retrieved shadow JSON document will be available 
-        in the registered callback. If no response is received within the provided timeout, a timeout 
+        Retrieve the device shadow JSON document from AWS IoT by publishing an empty JSON document to the
+        corresponding shadow topics. Shadow response topics will be subscribed to receive responses from
+        AWS IoT regarding the result of the get operation. Retrieved shadow JSON document will be available
+        in the registered callback. If no response is received within the provided timeout, a timeout
         notification will be passed into the registered callback.
 
         **Syntax**
@@ -213,12 +213,12 @@ class deviceShadow:
 
         **Parameters**
 
-        *srcCallback* - Function to be called when the response for this shadow request comes back. Should 
-        be in form :code:`customCallback(payload, responseStatus, token)`, where :code:`payload` is the 
-        JSON document returned, :code:`responseStatus` indicates whether the request has been accepted, 
+        *srcCallback* - Function to be called when the response for this shadow request comes back. Should
+        be in form :code:`customCallback(payload, responseStatus, token)`, where :code:`payload` is the
+        JSON document returned, :code:`responseStatus` indicates whether the request has been accepted,
         rejected or is a delta message, :code:`token` is the token used for tracing in this request.
 
-        *srcTimeout* - Timeout to determine whether the request is invalid. When a request gets timeout, 
+        *srcTimeout* - Timeout to determine whether the request is invalid. When a request gets timeout,
         a timeout notification will be generated and put into the registered callback to notify users.
 
         **Returns**
@@ -255,10 +255,10 @@ class deviceShadow:
         """
         **Description**
 
-        Delete the device shadow from AWS IoT by publishing an empty JSON document to the corresponding 
-        shadow topics. Shadow response topics will be subscribed to receive responses from AWS IoT 
-        regarding the result of the get operation. Responses will be available in the registered callback. 
-        If no response is received within the provided timeout, a timeout notification will be passed into 
+        Delete the device shadow from AWS IoT by publishing an empty JSON document to the corresponding
+        shadow topics. Shadow response topics will be subscribed to receive responses from AWS IoT
+        regarding the result of the get operation. Responses will be available in the registered callback.
+        If no response is received within the provided timeout, a timeout notification will be passed into
         the registered callback.
 
         **Syntax**
@@ -270,12 +270,12 @@ class deviceShadow:
 
         **Parameters**
 
-        *srcCallback* - Function to be called when the response for this shadow request comes back. Should 
-        be in form :code:`customCallback(payload, responseStatus, token)`, where :code:`payload` is the 
-        JSON document returned, :code:`responseStatus` indicates whether the request has been accepted, 
+        *srcCallback* - Function to be called when the response for this shadow request comes back. Should
+        be in form :code:`customCallback(payload, responseStatus, token)`, where :code:`payload` is the
+        JSON document returned, :code:`responseStatus` indicates whether the request has been accepted,
         rejected or is a delta message, :code:`token` is the token used for tracing in this request.
 
-        *srcTimeout* - Timeout to determine whether the request is invalid. When a request gets timeout, 
+        *srcTimeout* - Timeout to determine whether the request is invalid. When a request gets timeout,
         a timeout notification will be generated and put into the registered callback to notify users.
 
         **Returns**
@@ -312,10 +312,10 @@ class deviceShadow:
         """
         **Description**
 
-        Update the device shadow JSON document string from AWS IoT by publishing the provided JSON 
-        document to the corresponding shadow topics. Shadow response topics will be subscribed to 
-        receive responses from AWS IoT regarding the result of the get operation. Response will be 
-        available in the registered callback. If no response is received within the provided timeout, 
+        Update the device shadow JSON document string from AWS IoT by publishing the provided JSON
+        document to the corresponding shadow topics. Shadow response topics will be subscribed to
+        receive responses from AWS IoT regarding the result of the get operation. Response will be
+        available in the registered callback. If no response is received within the provided timeout,
         a timeout notification will be passed into the registered callback.
 
         **Syntax**
@@ -329,12 +329,12 @@ class deviceShadow:
 
         *srcJSONPayload* - JSON document string used to update shadow JSON document in AWS IoT.
 
-        *srcCallback* - Function to be called when the response for this shadow request comes back. Should 
-        be in form :code:`customCallback(payload, responseStatus, token)`, where :code:`payload` is the 
-        JSON document returned, :code:`responseStatus` indicates whether the request has been accepted, 
+        *srcCallback* - Function to be called when the response for this shadow request comes back. Should
+        be in form :code:`customCallback(payload, responseStatus, token)`, where :code:`payload` is the
+        JSON document returned, :code:`responseStatus` indicates whether the request has been accepted,
         rejected or is a delta message, :code:`token` is the token used for tracing in this request.
 
-        *srcTimeout* - Timeout to determine whether the request is invalid. When a request gets timeout, 
+        *srcTimeout* - Timeout to determine whether the request is invalid. When a request gets timeout,
         a timeout notification will be generated and put into the registered callback to notify users.
 
         **Returns**
@@ -374,8 +374,8 @@ class deviceShadow:
         """
         **Description**
 
-        Listen on delta topics for this device shadow by subscribing to delta topics. Whenever there 
-        is a difference between the desired and reported state, the registered callback will be called 
+        Listen on delta topics for this device shadow by subscribing to delta topics. Whenever there
+        is a difference between the desired and reported state, the registered callback will be called
         and the delta payload will be available in the callback.
 
         **Syntax**
@@ -387,9 +387,9 @@ class deviceShadow:
 
         **Parameters**
 
-        *srcCallback* - Function to be called when the response for this shadow request comes back. Should 
-        be in form :code:`customCallback(payload, responseStatus, token)`, where :code:`payload` is the 
-        JSON document returned, :code:`responseStatus` indicates whether the request has been accepted, 
+        *srcCallback* - Function to be called when the response for this shadow request comes back. Should
+        be in form :code:`customCallback(payload, responseStatus, token)`, where :code:`payload` is the
+        JSON document returned, :code:`responseStatus` indicates whether the request has been accepted,
         rejected or is a delta message, :code:`token` is the token used for tracing in this request.
 
         **Returns**
@@ -408,8 +408,8 @@ class deviceShadow:
         """
         **Description**
 
-        Cancel listening on delta topics for this device shadow by unsubscribing to delta topics. There will 
-        be no delta messages received after this API call even though there is a difference between the 
+        Cancel listening on delta topics for this device shadow by unsubscribing to delta topics. There will
+        be no delta messages received after this API call even though there is a difference between the
         desired and reported state.
 
         **Syntax**

--- a/AWSIoTPythonSDK/core/shadow/shadowManager.py
+++ b/AWSIoTPythonSDK/core/shadow/shadowManager.py
@@ -23,15 +23,20 @@ class _shadowAction:
     def __init__(self, srcShadowName, srcActionName):
         if srcActionName is None or srcActionName not in self._actionType:
             raise TypeError("Unsupported shadow action.")
-        self._shadowName = srcShadowName
         self._actionName = srcActionName
         self.isDelta = srcActionName == "delta"
-        if self.isDelta:
-            self._topicDelta = "$aws/things/" + str(self._shadowName) + "/shadow/update/delta"
+        if ':' in srcShadowName:
+            self._thingName, self._shadowName = srcShadowName.split(':')
+            shadowStem = self._thingName + "/shadow/name/" + self._shadowName + "/"
         else:
-            self._topicGeneral = "$aws/things/" + str(self._shadowName) + "/shadow/" + str(self._actionName)
-            self._topicAccept = "$aws/things/" + str(self._shadowName) + "/shadow/" + str(self._actionName) + "/accepted"
-            self._topicReject = "$aws/things/" + str(self._shadowName) + "/shadow/" + str(self._actionName) + "/rejected"
+            self._thingName = self._shadowName = srcShadowName
+            shadowStem = srcShadowName + "/shadow/"
+        if self.isDelta:
+            self._topicDelta = "$aws/things/" + shadowStem + "update/delta"
+        else:
+            self._topicGeneral = topic = "$aws/things/" + shadowStem + self._actionName
+            self._topicAccept = topic + "/accepted"
+            self._topicReject = topic + "/rejected"
 
     def getTopicGeneral(self):
         return self._topicGeneral


### PR DESCRIPTION
*Description of changes:*

Just for **named shadow** early testing cuz this new feature [AWS IoT Core now supports multiple shadows for a single IoT device](https://aws.amazon.com/tw/about-aws/whats-new/2020/07/aws-iot-core-now-supports-multiple-shadows-for-a-single-iot-device/) was published. 

An unofficial naming convention "**thingName:shadowName**" for **named shadow** with  the method ***createShadowHandlerWithName()*** of  *AWSIoTMQTTShadowClient* class