### PR TITLE
Add usage of specific SSL ciphers

### DIFF
--- a/AWSIoTPythonSDK/MQTTLib.py
+++ b/AWSIoTPythonSDK/MQTTLib.py
@@ -15,6 +15,7 @@
 # */
 
 from AWSIoTPythonSDK.core.util.providers import CertificateCredentialsProvider
+from AWSIoTPythonSDK.core.util.providers import CiphersProvider
 from AWSIoTPythonSDK.core.util.providers import IAMCredentialsProvider
 from AWSIoTPythonSDK.core.util.providers import EndpointProvider
 from AWSIoTPythonSDK.core.jobs.thingJobManager import jobExecutionTopicType
@@ -207,7 +208,7 @@ class AWSIoTMQTTClient:
         iam_credentials_provider.set_session_token(AWSSessionToken)
         self._mqtt_core.configure_iam_credentials(iam_credentials_provider)
 
-    def configureCredentials(self, CAFilePath, KeyPath="", CertificatePath=""):  # Should be good for MutualAuth certs config and Websocket rootCA config
+    def configureCredentials(self, CAFilePath, KeyPath="", CertificatePath="", Ciphers=None):  # Should be good for MutualAuth certs config and Websocket rootCA config
         """
         **Description**
 
@@ -227,6 +228,8 @@ class AWSIoTMQTTClient:
 
         *CertificatePath* - Path to read the certificate. Required for X.509 certificate based connection.
 
+        *Ciphers* - String of colon split SSL Ciphers to use. If not passed default ciphers will be used.
+
         **Returns**
 
         None
@@ -236,7 +239,11 @@ class AWSIoTMQTTClient:
         cert_credentials_provider.set_ca_path(CAFilePath)
         cert_credentials_provider.set_key_path(KeyPath)
         cert_credentials_provider.set_cert_path(CertificatePath)
-        self._mqtt_core.configure_cert_credentials(cert_credentials_provider)
+
+        cipher_provider = CiphersProvider()
+        cipher_provider.set_ciphers(Ciphers)
+
+        self._mqtt_core.configure_cert_credentials(cert_credentials_provider, cipher_provider)
 
     def configureAutoReconnectBackoffTime(self, baseReconnectQuietTimeSecond, maxReconnectQuietTimeSecond, stableConnectionTimeSecond):
         """

--- a/AWSIoTPythonSDK/core/protocol/internal/clients.py
+++ b/AWSIoTPythonSDK/core/protocol/internal/clients.py
@@ -64,7 +64,7 @@ class InternalAsyncMqttClient(object):
         return mqtt.Client(client_id, clean_session, user_data, protocol, use_wss)
 
     #  TODO: Merge credentials providers configuration into one
-    def set_cert_credentials_provider(self, cert_credentials_provider):
+    def set_cert_credentials_provider(self, cert_credentials_provider, ciphers_provider):
         # History issue from Yun SDK where AR9331 embedded Linux only have Python 2.7.3
         # pre-installed. In this version, TLSv1_2 is not even an option.
         # SSLv23 is a work-around which selects the highest TLS version between the client
@@ -75,13 +75,16 @@ class InternalAsyncMqttClient(object):
         # See also: https://docs.python.org/2/library/ssl.html#ssl.PROTOCOL_SSLv23
         if self._use_wss:
             ca_path = cert_credentials_provider.get_ca_path()
-            self._paho_client.tls_set(ca_certs=ca_path, cert_reqs=ssl.CERT_REQUIRED, tls_version=ssl.PROTOCOL_SSLv23)
+            ciphers = ciphers_provider.get_ciphers()
+            self._paho_client.tls_set(ca_certs=ca_path, cert_reqs=ssl.CERT_REQUIRED, tls_version=ssl.PROTOCOL_SSLv23,
+                                      ciphers=ciphers)
         else:
             ca_path = cert_credentials_provider.get_ca_path()
             cert_path = cert_credentials_provider.get_cert_path()
             key_path = cert_credentials_provider.get_key_path()
+            ciphers = ciphers_provider.get_ciphers()
             self._paho_client.tls_set(ca_certs=ca_path,certfile=cert_path, keyfile=key_path,
-                                      cert_reqs=ssl.CERT_REQUIRED, tls_version=ssl.PROTOCOL_SSLv23)
+                                      cert_reqs=ssl.CERT_REQUIRED, tls_version=ssl.PROTOCOL_SSLv23, ciphers=ciphers)
 
     def set_iam_credentials_provider(self, iam_credentials_provider):
         self._paho_client.configIAMCredentials(iam_credentials_provider.get_access_key_id(),

--- a/AWSIoTPythonSDK/core/protocol/mqtt_core.py
+++ b/AWSIoTPythonSDK/core/protocol/mqtt_core.py
@@ -127,9 +127,9 @@ class MqttCore(object):
     def on_offline(self):
         pass
 
-    def configure_cert_credentials(self, cert_credentials_provider):
-        self._logger.info("Configuring certificates...")
-        self._internal_async_client.set_cert_credentials_provider(cert_credentials_provider)
+    def configure_cert_credentials(self, cert_credentials_provider, ciphers_provider):
+        self._logger.info("Configuring certificates and ciphers...")
+        self._internal_async_client.set_cert_credentials_provider(cert_credentials_provider, ciphers_provider)
 
     def configure_iam_credentials(self, iam_credentials_provider):
         self._logger.info("Configuring custom IAM credentials...")

--- a/AWSIoTPythonSDK/core/util/providers.py
+++ b/AWSIoTPythonSDK/core/util/providers.py
@@ -90,3 +90,30 @@ class EndpointProvider(object):
 
     def get_port(self):
         return self._port
+
+
+class CiphersProvider(object):
+    def __init__(self):
+        self._ciphers = None
+        self.aws_iot_valid_ciphers = [
+            "ECDHE-ECDSA-AES128-GCM-SHA256", "ECDHE-RSA-AES128-GCM-SHA256", "ECDHE-ECDSA-AES128-SHA256",
+            "ECDHE-RSA-AES128-SHA256", "ECDHE-ECDSA-AES128-SHA", "ECDHE-RSA-AES128-SHA",
+            "ECDHE-ECDSA-AES256-GCM-SHA384", "ECDHE-RSA-AES256-GCM-SHA384", "ECDHE-ECDSA-AES256-SHA384",
+            "ECDHE-RSA-AES256-SHA384", "ECDHE-RSA-AES256-SHA", "ECDHE-ECDSA-AES256-SHA",
+            "AES128-GCM-SHA256", "AES128-SHA256", "AES128-SHA", "AES256-GCM-SHA384", "AES256-SHA256", "AES256-SHA"
+        ]
+
+    def set_ciphers(self, ciphers=None):
+        self._ciphers = ciphers
+
+    def get_ciphers(self):
+        return self._ciphers
+
+    # Not in use right now because lack of necessity of validate AWS IoT SSL Ciphers
+    def validate_ciphers(self):
+        # Getting intersection of valid ciphers between ciphers defined by user and AWS IoT valid ciphers.
+        try:
+            self._ciphers = ":".join(list(set(self._ciphers.split(":")) & set(self.aws_iot_valid_ciphers)))
+        except Exception as e:
+            print(e)
+            self._ciphers = None

--- a/AWSIoTPythonSDK/core/util/providers.py
+++ b/AWSIoTPythonSDK/core/util/providers.py
@@ -95,25 +95,9 @@ class EndpointProvider(object):
 class CiphersProvider(object):
     def __init__(self):
         self._ciphers = None
-        self.aws_iot_valid_ciphers = [
-            "ECDHE-ECDSA-AES128-GCM-SHA256", "ECDHE-RSA-AES128-GCM-SHA256", "ECDHE-ECDSA-AES128-SHA256",
-            "ECDHE-RSA-AES128-SHA256", "ECDHE-ECDSA-AES128-SHA", "ECDHE-RSA-AES128-SHA",
-            "ECDHE-ECDSA-AES256-GCM-SHA384", "ECDHE-RSA-AES256-GCM-SHA384", "ECDHE-ECDSA-AES256-SHA384",
-            "ECDHE-RSA-AES256-SHA384", "ECDHE-RSA-AES256-SHA", "ECDHE-ECDSA-AES256-SHA",
-            "AES128-GCM-SHA256", "AES128-SHA256", "AES128-SHA", "AES256-GCM-SHA384", "AES256-SHA256", "AES256-SHA"
-        ]
 
     def set_ciphers(self, ciphers=None):
         self._ciphers = ciphers
 
     def get_ciphers(self):
         return self._ciphers
-
-    # Not in use right now because lack of necessity of validate AWS IoT SSL Ciphers
-    def validate_ciphers(self):
-        # Getting intersection of valid ciphers between ciphers defined by user and AWS IoT valid ciphers.
-        try:
-            self._ciphers = ":".join(list(set(self._ciphers.split(":")) & set(self.aws_iot_valid_ciphers)))
-        except Exception as e:
-            print(e)
-            self._ciphers = None

--- a/README.rst
+++ b/README.rst
@@ -635,6 +635,18 @@ accepted/rejected topics.
 
 In all SDK examples, PersistentSubscription is used in consideration of its better performance.
 
+SSL Ciphers Setup
+______________________________________
+
+If custom SSL Ciphers are required for the client, they can be set when configuring the client before
+starting the connection.
+
+To setup specific SSL Ciphers:
+
+.. code-block:: python
+
+    myAWSIoTMQTTClient.configureCredentials(rootCAPath, privateKeyPath, certificatePath, Ciphers="AES128-SHA256")
+
 .. _Examples:
 
 Examples


### PR DESCRIPTION
Allow the setup of specific SSL ciphers without affecting the current usage of the client. If specific ciphers are not used, the generic ones will be used, allowing the client to work as it works currently.