### PR TITLE
Init offline request queue exceptions on raise

### DIFF
--- a/AWSIoTPythonSDK/core/protocol/mqtt_core.py
+++ b/AWSIoTPythonSDK/core/protocol/mqtt_core.py
@@ -91,14 +91,14 @@ class MqttCore(object):
 
     def _init_offline_request_exceptions(self):
         self._offline_request_queue_disabled_exceptions = {
-            RequestTypes.PUBLISH : publishQueueDisabledException(),
-            RequestTypes.SUBSCRIBE : subscribeQueueDisabledException(),
-            RequestTypes.UNSUBSCRIBE : unsubscribeQueueDisabledException()
+            RequestTypes.PUBLISH : publishQueueDisabledException,
+            RequestTypes.SUBSCRIBE : subscribeQueueDisabledException,
+            RequestTypes.UNSUBSCRIBE : unsubscribeQueueDisabledException
         }
         self._offline_request_queue_full_exceptions = {
-            RequestTypes.PUBLISH : publishQueueFullException(),
-            RequestTypes.SUBSCRIBE : subscribeQueueFullException(),
-            RequestTypes.UNSUBSCRIBE : unsubscribeQueueFullException()
+            RequestTypes.PUBLISH : publishQueueFullException,
+            RequestTypes.SUBSCRIBE : subscribeQueueFullException,
+            RequestTypes.UNSUBSCRIBE : unsubscribeQueueFullException
         }
 
     def _init_workers(self):
@@ -367,7 +367,7 @@ class MqttCore(object):
         append_result = self._offline_requests_manager.add_one(offline_request)
         if AppendResults.APPEND_FAILURE_QUEUE_DISABLED == append_result:
             self._logger.error("Offline request queue has been disabled")
-            raise self._offline_request_queue_disabled_exceptions[type]
+            raise self._offline_request_queue_disabled_exceptions[type]()
         if AppendResults.APPEND_FAILURE_QUEUE_FULL == append_result:
             self._logger.error("Offline request queue is full")
-            raise self._offline_request_queue_full_exceptions[type]
+            raise self._offline_request_queue_full_exceptions[type]()


### PR DESCRIPTION
This causes the exception stack trace to be added to the instance
every time the exception is raised, increasing memory usage and causing
a memory leak.

The state to exception map is preserved without initialising the
exceptions, instead they are initialised when needed to be raised.

Fixes: 333ffdb

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
