### PR TITLE
Fix issue #284. Keep usage of _basicJSONParserHandler inside the _dataStructureLock block

### DIFF
--- a/AWSIoTPythonSDK/core/shadow/deviceShadow.py
+++ b/AWSIoTPythonSDK/core/shadow/deviceShadow.py
@@ -27,6 +27,14 @@ class _shadowRequestToken:
         return uuid.uuid4().urn[self.URN_PREFIX_LENGTH:]  # We only need the uuid digits, not the urn prefix
 
 
+def _validateJSON(jsonString):
+    try:
+        json.loads(jsonString)
+    except ValueError:
+        return False
+    return True
+
+
 class _basicJSONParser:
 
     def setString(self, srcString):
@@ -343,9 +351,10 @@ class deviceShadow:
 
         """
         # Validate JSON
-        self._basicJSONParserHandler.setString(srcJSONPayload)
-        if self._basicJSONParserHandler.validateJSON():
+        if _validateJSON(srcJSONPayload):
             with self._dataStructureLock:
+                self._basicJSONParserHandler.setString(srcJSONPayload)
+                self._basicJSONParserHandler.validateJSON()
                 # clientToken
                 currentToken = self._tokenHandler.getNextToken()
                 self._tokenPool[currentToken] = Timer(srcTimeout, self._timerHandler, ["update", currentToken])


### PR DESCRIPTION
Issue #284

*Description of changes:*
The shadowUpdate() method was using the member variable object _basicJSONParserHandler in a thread-unsafe manner, such that a different thread would overwrite the _dictionaryObject prior to the first thread acquiring the _dataStructureLock. This change puts all usage of _basicJSONParserHandler inside the _dataStructureLock block, while keeping the validation logic the same.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
