### PR TITLE
fix: use string representation of error (Fixes #289)

### DIFF
--- a/samples/greengrass/basicDiscovery.py
+++ b/samples/greengrass/basicDiscovery.py
@@ -123,13 +123,13 @@ while retryCount != 0:
     except DiscoveryInvalidRequestException as e:
         print("Invalid discovery request detected!")
         print("Type: %s" % str(type(e)))
-        print("Error message: %s" % e.message)
+        print("Error message: %s" % str(e))
         print("Stopping...")
         break
     except BaseException as e:
         print("Error in discovery!")
         print("Type: %s" % str(type(e)))
-        print("Error message: %s" % e.message)
+        print("Error message: %s" % str(e))
         retryCount -= 1
         print("\n%d/%d retries left\n" % (retryCount, MAX_DISCOVERY_RETRIES))
         print("Backing off...\n")
@@ -157,7 +157,7 @@ for connectivityInfo in coreInfo.connectivityInfoList:
     except BaseException as e:
         print("Error in connect!")
         print("Type: %s" % str(type(e)))
-        print("Error message: %s" % e.message)
+        print("Error message: %s" % str(e))
 
 if not connected:
     print("Cannot connect to core %s. Exiting..." % coreInfo.coreThingArn)


### PR DESCRIPTION
A BaseException does not always have a message field.

Traceback (most recent call last):
  File "basicDiscovery.py", line 160, in <module>
    print("Error message: %s" % e.message)
AttributeError: 'ConnectionRefusedError' object has no attribute 'message'

*Issue #, if available:* 289

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
