### PR TITLE
setup.py: Use setuptools instead of distutils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ sys.path.insert(0, 'AWSIoTPythonSDK')
 import AWSIoTPythonSDK
 currentVersion = AWSIoTPythonSDK.__version__
 
-from distutils.core import setup
+from setuptools import setup
 setup(
     name = 'AWSIoTPythonSDK',
     packages=['AWSIoTPythonSDK', 'AWSIoTPythonSDK.core',


### PR DESCRIPTION
distutils is deprecated and will be gone in 3.12+

Signed-off-by: Khem Raj <raj.khem@gmail.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
