### PR TITLE
Fixed list type check condition always returning false

### DIFF
--- a/AWSIoTPythonSDK/core/greengrass/discovery/providers.py
+++ b/AWSIoTPythonSDK/core/greengrass/discovery/providers.py
@@ -370,7 +370,7 @@ class DiscoveryInfoProvider(object):
         while True:  # Python does not have do-while
             try:
                 ssl_sock_tmp = self._convert_to_int_py3(ssl_sock.read(1))
-                if type(ssl_sock_tmp) is list:
+                if isinstance(ssl_sock_tmp, list):
                     response.extend(ssl_sock_tmp)
                 else:
                     response.append(ssl_sock_tmp)

--- a/AWSIoTPythonSDK/core/greengrass/discovery/providers.py
+++ b/AWSIoTPythonSDK/core/greengrass/discovery/providers.py
@@ -370,7 +370,7 @@ class DiscoveryInfoProvider(object):
         while True:  # Python does not have do-while
             try:
                 ssl_sock_tmp = self._convert_to_int_py3(ssl_sock.read(1))
-                if ssl_sock_tmp is list:
+                if type(ssl_sock_tmp) is list:
                     response.extend(ssl_sock_tmp)
                 else:
                     response.append(ssl_sock_tmp)


### PR DESCRIPTION
*Description of changes:*

Fixes issue where the condition for checking if the type is a list would always return `false`.

____________

*By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.*
