### PR TITLE
Use PyPi token specific to the Python V1 SDK

### DIFF
--- a/continuous-delivery/publish_to_prod_pypi.yml
+++ b/continuous-delivery/publish_to_prod_pypi.yml
@@ -11,7 +11,7 @@ phases:
   pre_build:
     commands:
       - cd aws-iot-device-sdk-python
-      - pypirc=$(aws secretsmanager get-secret-value --secret-id "prod/aws-crt-python/.pypirc" --query "SecretString" | cut -f2 -d\") && echo "$pypirc" > ~/.pypirc
+      - pypirc=$(aws secretsmanager get-secret-value --secret-id "prod/aws-sdk-python-v1/.pypirc" --query "SecretString" | cut -f2 -d\") && echo "$pypirc" > ~/.pypirc
       - export PKG_VERSION=$(git describe --tags | cut -f2 -dv)
       - echo "Updating package version to ${PKG_VERSION}"
       - sed --in-place -E "s/__version__ = \".+\"/__version__ = \"${PKG_VERSION}\"/" AWSIoTPythonSDK/__init__.py


### PR DESCRIPTION
*Description of changes:*

Use a PyPi token that is specific to the Python V1 SDK for releases.

__________

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
