### PR TITLE
Fix link in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
 New Version Available	
 =============================
-A new AWS IoT Device SDK is [now available](https://github.com/awslabs/aws-iot-device-sdk-python-v2). It is a complete rework, built to improve reliability, performance, and security. We invite your feedback!	
+A new AWS IoT Device SDK is `now available <https://github.com/awslabs/aws-iot-device-sdk-python-v2>`__. It is a complete rework, built to improve reliability, performance, and security. We invite your feedback!
 
 This SDK will no longer receive feature updates, but will receive security updates.	
 


### PR DESCRIPTION
The readme file has `.rst`, so markdown syntax doesn't work there.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
